### PR TITLE
Allow to compile on *BSD systems

### DIFF
--- a/src/sass/libsass.nim
+++ b/src/sass/libsass.nim
@@ -1,6 +1,6 @@
 when defined(macosx):
   const libsass = "libsass.dylib"
-elif defined(linux):
+elif defined(linux) or defined(bsd):
   const libsass = "libsass.so"
 else:
   const libsass = "libsass.dll"


### PR DESCRIPTION
*BSD systems also use .so libraries, not .dll