### PR TITLE
compile on haiku

### DIFF
--- a/src/sass/libsass.nim
+++ b/src/sass/libsass.nim
@@ -2,6 +2,8 @@ when defined(macosx):
   const libsass = "libsass.dylib"
 elif defined(linux) or defined(bsd):
   const libsass = "libsass.so"
+elif defined(haiku):
+  const libsass = "libsass.so.1.0.0"
 else:
   const libsass = "libsass.dll"
 


### PR DESCRIPTION
this pr fixes compilation on haiku

sample run below:

```
> uname -a
Haiku shredder 1 hrev56098 May 13 2022 08:04:13 x86_64 x86_64 Haiku


> nimble test
  Executing task test in /boot/home/src/git/nim-libs/sass/sass.nimble
Hint: used config file '/boot/system/lib/nim/config/nim.cfg' [Conf]
Hint: used config file '/boot/system/lib/nim/config/config.nims' [Conf]
Hint: used config file '/boot/home/src/git/nim-libs/sass/tests/tester.nims' [Conf]
......................................................................................................
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(22, 26) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(240, 41) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(242, 43) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(250, 52) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(252, 49) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(256, 50) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(282, 54) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass/libsass.nim(288, 54) Warning: use `csize_t` instead; csize is deprecated [Deprecated]
/boot/home/src/git/nim-libs/sass/src/sass.nim(24, 20) Warning: inherit from a more precise exception type like ValueError, IOError or OSError. If these don't suit, inherit from CatchableError or Defect. [InheritFromException]
/boot/home/src/git/nim-libs/sass/src/sass.nim(49, 13) template/generic instantiation of `setOptions` from here
/boot/home/src/git/nim-libs/sass/src/sass.nim(35, 32) Warning: implicit conversion to 'cstring' from a non-const location: p; this will become a compile time error in the future [CStringConv]
/boot/home/src/git/nim-libs/sass/src/sass.nim(65, 13) template/generic instantiation of `setOptions` from here
/boot/home/src/git/nim-libs/sass/src/sass.nim(35, 32) Warning: implicit conversion to 'cstring' from a non-const location: p; this will become a compile time error in the future [CStringConv]
CC: ../src/sass/libsass.nim
Hint:  [Link]
Hint: gc: refc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
90531 lines; 0.995s; 117.441MiB peakmem; proj: /boot/home/src/git/nim-libs/sass/tests/tester; out: /boot/home/src/git/nim-libs/sass/tests/tester [SuccessX]
Hint: /boot/home/src/git/nim-libs/sass/tests/tester  [Exec]
[OK] can compile string
[OK] can set options
[OK] can compile file (Sass)
[OK] can compile file (SCSS)
[OK] can report errors
```