### PR TITLE
support `sourceMap` | add `compileSass` proc

### DIFF
--- a/src/sass.nim
+++ b/src/sass.nim
@@ -15,61 +15,101 @@
 ## * includePaths - A list of include paths.
 
 import os
-
 import sass/libsass
+from strutils import spaces
 
 export OutputStyle
 
 type
-  SassException* = object of Exception
+  SassException* = object of CatchableError
 
 proc strdup(str: cstring): cstring {.header: "<string.h>", importc.}
 
 proc setOptions*(ctx: ptr Context | ptr DataContext | ptr FileContext,
                  precision: cint, outputStyle: OutputStyle,
-                 includePaths: seq[string], outputPath: string) =
+                 includePaths: seq[string], outputPath = "",
+                 indent = 2, sourceMapEmbed,
+                 sourceMapContents, sourceMapFile = false): ptr Options {.discardable.} =
   let opts = ctx.getOptions()
   opts.setPrecision(precision)
-  opts.setOutputStyle(outputStyle)
+  opts.setOutputStyle(outputStyle)  # Output style: Nested, Expanded, Compact, Compressed
+  opts.setIndent(indent.spaces().cstring)   # Base indentation (default 2)
+  var toSourceMapFile: bool
+  if sourceMapEmbed:
+    opts.setSourceMapEmbed(true)
+    opts.setSourceMapContents(sourceMapContents)
+  elif sourceMapFile:
+    toSourceMapFile = true
+
   for p in includePaths:
     let allocatedData = strdup(p)
     opts.pushIncludePath(allocatedData)
   if outputPath.len > 0:
     opts.setOutputPath(outputPath)
+    if toSourceMapFile:
+      opts.setSourceMapFileUrls(true)
+      opts.setSourceMapFile(outputPath.changeFileExt(".css.map").cstring)
+      opts.setSourceMapContents(sourceMapContents)
+  result = opts
+
+template setContext(dataFile: string, isDataCtx: static bool = false) =
+  let allocatedData = strdup(dataFile)
+  when isDataCtx:
+    fdCtx = makeDataContext(allocatedData)
+  else:
+    fdCtx = makeFileContext(allocatedData)
+  defer:
+    fdCtx.delete()
+
+template toCss(): untyped =
+  let ctx = fdCtx.getContext()
+  if fdCtx.compile() != 0:
+    raise newException(SassException, $ctx.get_error_text())
+  when declared outputPath:
+    let outputPath =
+      if outputPath.len == 0:
+        filename.changeFileExt("css")
+      else:
+        outputPath
+    writeFile(outputPath, $ctx.getOutputString())
+    if opts.getSourceMapFile.len != 0:
+      writeFile($opts.getSourceMapFile, $getSourceMapString(ctx))
+  else:
+    $ctx.getOutputString()
+#
+# Public API
+#
+proc compileSass*(data: string, precision: int = 5,
+                  outputStyle: OutputStyle = Nested,
+                  includePaths: seq[string] = @[], indent = 2,
+                  sourceMapEmbed, sourceMapContents = false): string =
+  ## Compiles a `SASS` string and returns the `CSS` output
+  var fdCtx: ptr DataContext
+  setContext data, true
+  setOptions(fdCtx, precision.cint, outputStyle, includePaths,
+            "", indent, sourceMapEmbed, sourceMapContents)
+            .setIsIndentedSyntaxSrc(true)
+  toCss
 
 proc compile*(data: string, precision: int = 5,
               outputStyle: OutputStyle = Nested,
-              includePaths: seq[string] = @[]): string =
-  ## Compiles a Sass/SCSS string to CSS.
-  let allocatedData = strdup(data)
-  let dataCtx = makeDataContext(allocatedData)
-  defer:
-    dataCtx.delete()
-
-  setOptions(dataCtx, precision.cint, outputStyle, includePaths, "")
-  let ctx = dataCtx.getContext()
-  if dataCtx.compile() != 0:
-    raise newException(SassException, $ctx.get_error_text())
-
-  result = $ctx.getOutputString()
-
+              includePaths: seq[string] = @[], indent = 2,
+              sourceMapEmbed, sourceMapContents, fromSass = false): string =
+  ## Compiles a SCSS string to CSS.
+  var fdCtx: ptr DataContext
+  setContext data, true
+  setOptions(fdCtx, precision.cint, outputStyle, includePaths,
+            "", indent, sourceMapEmbed, sourceMapContents)
+  toCss
 
 proc compileFile*(filename: string, outputPath = "",
                   precision: int = 5, outputStyle: OutputStyle = Nested,
-                  includePaths: seq[string] = @[]) =
-  let allocatedFilename = strdup(filename)
-  let fileCtx = makeFileContext(allocatedFilename)
-  defer:
-    fileCtx.delete()
-
-  setOptions(fileCtx, precision.cint, outputStyle, includePaths, outputPath)
-  let ctx = fileCtx.getContext()
-  if fileCtx.compile() != 0:
-    raise newException(SassException, $ctx.get_error_text())
-
-  let outputPath =
-    if outputPath.len == 0:
-      filename.changeFileExt("css")
-    else:
-      outputPath
-  writeFile(outputPath, $ctx.getOutputString())
+                  includePaths: seq[string] = @[], indent = 2,
+                  sourceMapEmbed, sourceMapFile, sourceMapContents = false) =
+  ## Compiles a Sass/SCSS file to CSS.
+  var fdCtx: ptr FileContext
+  setContext filename
+  let opts = setOptions(fdCtx, precision.cint, outputStyle,
+              includePaths, outputPath, indent,
+              sourceMapEmbed, sourceMapContents, sourceMapFile)
+  toCss

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1,12 +1,44 @@
 import unittest, strutils, os
-
 import sass
 
-test "can compile string":
-  check "color: red;" in compile("body { div { color: red; } }")
+let strSass = """
+body
+  div
+    color: red
+"""
+
+let strScss = """
+body {
+  div {
+    color: red
+  }
+}
+"""
+
+test "can compile string (Scss)":
+  check "color: red;" in compile(strScss)
+
+test "can compile w/ custom indent (Scss)":
+  let css = compile(strScss, indent = 4, outputStyle = Expanded)
+  let lines = css.splitLines()
+  check lines.len == 4
+  check lines[1][0..3] == spaces(4)
+
+test "can compile string (Sass)":
+  check "color: red;" in compileSass(strSass)
+
+test "can compile w/ custom indent (Sass)":
+  let css = compileSass(strSass, indent = 4, outputStyle = Expanded)
+  let lines = css.splitLines()
+  check lines.len == 4
+  check lines[1][0..3] == spaces(4)
+
+test "can embed sourceMappingUrl as data uri":
+  let css = compile(strScss, sourceMapEmbed = true, sourceMapContents = true)
+  check "sourceMappingURL=data:application/json" in css
 
 test "can set options":
-  let css = compile("body { div { color: red; } }", outputStyle=Compact)
+  let css = compile(strScss, outputStyle=Compact)
   check css.splitLines().len == 2
 
 test "can compile file (Sass)":
@@ -16,6 +48,10 @@ test "can compile file (Sass)":
 test "can compile file (SCSS)":
   compileFile("tests/basic.scss", "tests/basic.css")
   check fileExists("tests/basic.css")
+
+test "can compile file with source map":
+  compileFile("tests/basic.scss", "tests/basic.css", sourceMapFile = true)
+  check fileExists("tests/basic.css.map")
 
 test "can report errors":
   expect SassException:


### PR DESCRIPTION
- Enable source map generation `sourceMappingUrl`  as URL / embedded as data URI.
- Indentation (default to 2)
- `compileSass` proc
- added unit tests

The current `compile` proc does not work with string-based sass code, because `is_indented_syntax_src` is not enabled, so I decided to write a separate `compileSass` handler.

And I couldn't resist and I wrote some templates just to keep things fresh and sharp.

Breaking changes: Nope

From [API Context](https://github.com/sass/libsass/blob/master/docs/api-context.md).
